### PR TITLE
Fix ESM dist imports to include .js extensions

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,1 +1,1 @@
-export { ProseWriter, write } from './prose-writer';
+export { ProseWriter, write } from './prose-writer.js';

--- a/src/markdown.ts
+++ b/src/markdown.ts
@@ -1,1 +1,1 @@
-export { bold, code, image, inline, italic, link, strike } from './prose-writer';
+export { bold, code, image, inline, italic, link, strike } from './prose-writer.js';

--- a/src/safe.ts
+++ b/src/safe.ts
@@ -1,3 +1,3 @@
-import { write as baseWrite } from './prose-writer';
+import { write as baseWrite } from './prose-writer.js';
 
 export const write = baseWrite.safe;

--- a/src/schema.ts
+++ b/src/schema.ts
@@ -1,1 +1,1 @@
-export type { SchemaEmbedOptions } from './prose-writer';
+export type { SchemaEmbedOptions } from './prose-writer.js';

--- a/src/validation.ts
+++ b/src/validation.ts
@@ -4,9 +4,9 @@ export type {
   ValidationIssue,
   ValidationOptions,
   ValidationResult,
-} from './prose-writer';
+} from './prose-writer.js';
 export {
   createJsonSchemaValidator,
   createYamlParserAdapter,
   ValidationError,
-} from './prose-writer';
+} from './prose-writer.js';

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -2,6 +2,8 @@
   "extends": "./tsconfig.json",
   "compilerOptions": {
     "noEmit": false,
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
     "declaration": true,
     "emitDeclarationOnly": false,
     "allowImportingTsExtensions": false,


### PR DESCRIPTION
## Summary
- switch source re-exports/imports in public entry modules to explicit `./prose-writer.js` specifiers
- set `tsconfig.build.json` to `module`/`moduleResolution` `NodeNext` so build-time resolution follows Node ESM rules
- verify dist output now emits `.js` relative imports (fixes Node/Vite ESM runtime resolution)

## Validation
- `bun run build`
- `bun run typecheck`
- `bun test`
- `node -e "import('./dist/index.js')"`

Closes #1

<!--DEPICT-ACTION-ITEMS-START-->
## Action Items

_No action items yet._

<!--DEPICT-ACTION-ITEMS-END-->